### PR TITLE
Support OES_depth_texture through MetalANGLE (commit 30426abb)

### DIFF
--- a/Source/ThirdParty/angle/src/compiler/translator/TranslatorMetal.h
+++ b/Source/ThirdParty/angle/src/compiler/translator/TranslatorMetal.h
@@ -5,8 +5,11 @@
 //
 // TranslatorMetal:
 //   A GLSL-based translator that outputs shaders that fit GL_KHR_vulkan_glsl.
+//   It takes into account some considerations for Metal backend also.
 //   The shaders are then fed into glslang to spit out SPIR-V (libANGLE-side).
 //   See: https://www.khronos.org/registry/vulkan/specs/misc/GL_KHR_vulkan_glsl.txt
+//
+//   The SPIR-V will then be translated to Metal Shading Language later in Metal backend.
 //
 
 #ifndef LIBANGLE_RENDERER_METAL_TRANSLATORMETAL_H_
@@ -26,6 +29,9 @@ class TranslatorMetal : public TranslatorVulkan
     ANGLE_NO_DISCARD bool translate(TIntermBlock *root,
                                     ShCompileOptions compileOptions,
                                     PerformanceDiagnostics *perfDiagnostics) override;
+
+    ANGLE_NO_DISCARD bool transformDepthBeforeCorrection(TIntermBlock *root,
+                                                         const TVariable *driverUniforms) override;
 };
 
 }  // namespace sh

--- a/Source/ThirdParty/angle/src/compiler/translator/TranslatorVulkan.h
+++ b/Source/ThirdParty/angle/src/compiler/translator/TranslatorVulkan.h
@@ -31,11 +31,23 @@ class TranslatorVulkan : public TCompiler
     bool shouldFlattenPragmaStdglInvariantAll() override;
 
     TIntermBinary *getDriverUniformNegViewportYScaleRef(const TVariable *driverUniforms) const;
-    ANGLE_NO_DISCARD bool preWriting(TIntermBlock *root,
-                                     ShCompileOptions compileOptions,
-                                     PerformanceDiagnostics *perfDiagnostics,
-                                     const TVariable **driverUniformsOut,
-                                     TOutputVulkanGLSL *outputGLSL);
+    TIntermBinary *getDriverUniformDepthRangeReservedFieldRef(
+        const TVariable *driverUniforms) const;
+    // Subclass can call this method to transform the AST before writing the final output.
+    // See TranslatorMetal.cpp.
+    ANGLE_NO_DISCARD bool translateImpl(TIntermBlock *root,
+                                        ShCompileOptions compileOptions,
+                                        PerformanceDiagnostics *perfDiagnostics,
+                                        const TVariable **driverUniformsOut,
+                                        TOutputVulkanGLSL *outputGLSL);
+
+    // Give subclass such as TranslatorMetal a chance to do depth transform before
+    // TranslatorVulkan apply its own transform.
+    ANGLE_NO_DISCARD virtual bool transformDepthBeforeCorrection(TIntermBlock *root,
+                                                                 const TVariable *driverUniforms)
+    {
+        return true;
+    }
 };
 
 }  // namespace sh

--- a/Source/ThirdParty/angle/src/libANGLE/renderer/metal/ContextMtl.h
+++ b/Source/ThirdParty/angle/src/libANGLE/renderer/metal/ContextMtl.h
@@ -343,7 +343,7 @@ class ContextMtl : public ContextImpl, public mtl::Context
         int32_t xfbBufferOffsets[4];
         uint32_t acbBufferOffsets[4];
 
-        // We'll use x, y, z for near / far / diff respectively.
+        // We'll use x, y, z, w for near / far / diff / zscale respectively.
         float depthRange[4];
     };
 

--- a/Source/ThirdParty/angle/src/libANGLE/renderer/metal/FrameBufferMtl.h
+++ b/Source/ThirdParty/angle/src/libANGLE/renderer/metal/FrameBufferMtl.h
@@ -24,9 +24,7 @@ class SurfaceMtl;
 class FramebufferMtl : public FramebufferImpl
 {
   public:
-    explicit FramebufferMtl(const gl::FramebufferState &state,
-                            bool flipY,
-                            bool alwaysDiscardDepthStencil);
+    explicit FramebufferMtl(const gl::FramebufferState &state, bool flipY, bool defaultFbo);
     ~FramebufferMtl() override;
     void destroy(const gl::Context *context) override;
 
@@ -86,6 +84,7 @@ class FramebufferMtl : public FramebufferImpl
     RenderTargetMtl *getColorReadRenderTarget() const;
 
     bool flipY() const { return mFlipY; }
+    bool isDefault() const { return mIsDefaultFBO; }
 
     gl::Rectangle getCompleteRenderArea() const;
 
@@ -146,7 +145,7 @@ class FramebufferMtl : public FramebufferImpl
     RenderTargetMtl *mStencilRenderTarget = nullptr;
     bool mDiscardStencil                  = false;
     mtl::RenderPassDesc mRenderPassDesc;
-    const bool mAlwaysDiscardDepthStencil;
+    const bool mIsDefaultFBO;
     const bool mFlipY = false;
 };
 }  // namespace rx

--- a/Source/ThirdParty/angle/src/libANGLE/renderer/metal/README.md
+++ b/Source/ThirdParty/angle/src/libANGLE/renderer/metal/README.md
@@ -15,7 +15,7 @@ Otherwise, a CPU conversion will take place.~~
 
 # Failed ANGLE end2end tests
 - DifferentStencilMasksTest.DrawWithDifferentMask
-- MipmapTest.DefineValidExtraLevelAndUseItLater
+- ~~MipmapTest.DefineValidExtraLevelAndUseItLater~~
 - PointSpritesTest.PointSizeAboveMaxIsClamped (point outside framebuffer won't get drawn)
 - SimpleStateChangeTest.CopyTexSubImageOnTextureBoundToFrambuffer (GL_ANGLE_framebuffer_blit not implemented)
 - ~~WebGLReadOutsideFramebufferTest.*~~

--- a/Source/ThirdParty/angle/src/libANGLE/renderer/metal/SurfaceMtl.mm
+++ b/Source/ThirdParty/angle/src/libANGLE/renderer/metal/SurfaceMtl.mm
@@ -274,7 +274,7 @@ egl::Error SurfaceMtl::initialize(const egl::Display *display)
 FramebufferImpl *SurfaceMtl::createDefaultFramebuffer(const gl::Context *context,
                                                       const gl::FramebufferState &state)
 {
-    auto fbo = new FramebufferMtl(state, /* flipY */ true, /* alwaysDiscard */ true);
+    auto fbo = new FramebufferMtl(state, /* flipY */ true, /* isDefault */ true);
 
     return fbo;
 }

--- a/Source/ThirdParty/angle/src/libANGLE/renderer/metal/TextureMtl.h
+++ b/Source/ThirdParty/angle/src/libANGLE/renderer/metal/TextureMtl.h
@@ -161,6 +161,7 @@ class TextureMtl : public TextureImpl
 
   private:
     void releaseTexture(bool releaseImages);
+    angle::Result ensureSamplerStateCreated(const gl::Context *context);
     // Ensure image at given index is created:
     angle::Result ensureImageCreated(const gl::Context *context, const gl::ImageIndex &index);
     angle::Result checkForEmulatedChannels(const gl::Context *context,

--- a/Source/ThirdParty/angle/src/libANGLE/renderer/metal/TextureMtl.mm
+++ b/Source/ThirdParty/angle/src/libANGLE/renderer/metal/TextureMtl.mm
@@ -10,6 +10,7 @@
 
 #include "libANGLE/renderer/metal/TextureMtl.h"
 
+#include "common/Color.h"
 #include "common/MemoryBuffer.h"
 #include "common/debug.h"
 #include "common/mathutil.h"
@@ -114,6 +115,209 @@ gl::TextureType GetTextureImageType(gl::TextureType texType)
     }
 }
 
+angle::Result UploadTextureContentsToStagingBuffer(ContextMtl *contextMtl,
+                                                   const angle::Format &textureAngleFormat,
+                                                   const angle::Format &stagingAngleFormat,
+                                                   const MTLSize &regionSize,
+                                                   const uint8_t *data,
+                                                   size_t bytesPerRow,
+                                                   size_t *bufferRowPitchOut,
+                                                   size_t *buffer2DImageSizeOut,
+                                                   mtl::BufferRef *bufferOut)
+{
+    // NOTE(hqle): 3D textures not supported yet.
+    ASSERT(regionSize.depth == 1);
+
+    size_t stagingBufferRowPitch    = regionSize.width * stagingAngleFormat.pixelBytes;
+    size_t stagingBuffer2DImageSize = stagingBufferRowPitch * regionSize.height;
+    size_t stagingBufferSize        = stagingBuffer2DImageSize * regionSize.depth;
+    mtl::BufferRef stagingBuffer;
+    ANGLE_TRY(mtl::Buffer::MakeBuffer(contextMtl, stagingBufferSize, nullptr, &stagingBuffer));
+
+    uint8_t *pdst = stagingBuffer->map(contextMtl);
+
+    if (textureAngleFormat.id == stagingAngleFormat.id)
+    {
+        const uint8_t *psrc = data;
+        for (NSUInteger r = 0; r < regionSize.height; ++r)
+        {
+            memcpy(pdst, psrc, stagingBufferRowPitch);
+            pdst += stagingBufferRowPitch;
+            psrc += bytesPerRow;
+        }
+    }
+    else
+    {
+        // This is only for depth & stencil case.
+        ASSERT(textureAngleFormat.depthBits || textureAngleFormat.stencilBits);
+        ASSERT(textureAngleFormat.pixelReadFunction && stagingAngleFormat.pixelWriteFunction);
+
+        // cache to store read result of source pixel
+        angle::DepthStencil depthStencilData;
+        auto sourcePixelReadData = reinterpret_cast<uint8_t *>(&depthStencilData);
+        ASSERT(textureAngleFormat.pixelBytes <= sizeof(depthStencilData));
+
+        for (NSUInteger r = 0; r < regionSize.height; ++r)
+        {
+            for (NSUInteger c = 0; c < regionSize.width; ++c)
+            {
+                const uint8_t *sourcePixelData =
+                    data + r * bytesPerRow + c * textureAngleFormat.pixelBytes;
+
+                uint8_t *destPixelData =
+                    pdst + r * stagingBufferRowPitch + c * stagingAngleFormat.pixelBytes;
+
+                textureAngleFormat.pixelReadFunction(sourcePixelData, sourcePixelReadData);
+                stagingAngleFormat.pixelWriteFunction(sourcePixelReadData, destPixelData);
+            }
+        }
+    }
+
+    stagingBuffer->unmap(contextMtl);
+
+    *bufferOut            = stagingBuffer;
+    *bufferRowPitchOut    = stagingBufferRowPitch;
+    *buffer2DImageSizeOut = stagingBuffer2DImageSize;
+
+    return angle::Result::Continue;
+}
+
+angle::Result UploadTextureContentsWithStagingBuffer(ContextMtl *contextMtl,
+                                                     const mtl::TextureRef &texture,
+                                                     const angle::Format &textureAngleFormat,
+                                                     MTLRegion region,
+                                                     uint32_t mipmapLevel,
+                                                     uint32_t slice,
+                                                     const uint8_t *data,
+                                                     size_t bytesPerRow)
+{
+    ASSERT(texture && texture->valid());
+
+    ASSERT(!texture->isCPUAccessible());
+
+    ASSERT(!textureAngleFormat.depthBits || !textureAngleFormat.stencilBits);
+
+    // Compressed texture is not supporte atm
+    ASSERT(!textureAngleFormat.isBlock);
+
+    // Copy data to staging buffer
+    size_t stagingBufferRowPitch;
+    size_t stagingBuffer2DImageSize;
+    mtl::BufferRef stagingBuffer;
+    ANGLE_TRY(UploadTextureContentsToStagingBuffer(
+        contextMtl, textureAngleFormat, textureAngleFormat, region.size, data, bytesPerRow,
+        &stagingBufferRowPitch, &stagingBuffer2DImageSize, &stagingBuffer));
+
+    // Copy staging buffer to texture.
+    mtl::BlitCommandEncoder *encoder = contextMtl->getBlitCommandEncoder();
+    encoder->copyBufferToTexture(stagingBuffer, 0, stagingBufferRowPitch, stagingBuffer2DImageSize,
+                                 region.size, texture, slice, mipmapLevel, region.origin,
+                                 MTLBlitOptionNone);
+
+    return angle::Result::Continue;
+}
+
+// Packed depth stencil upload using staging buffer
+angle::Result UploadPackedDepthStencilTextureContentsWithStagingBuffer(
+    ContextMtl *contextMtl,
+    const mtl::TextureRef &texture,
+    const angle::Format &textureAngleFormat,
+    MTLRegion region,
+    uint32_t mipmapLevel,
+    uint32_t slice,
+    const uint8_t *data,
+    size_t bytesPerRow)
+{
+    ASSERT(texture && texture->valid());
+
+    ASSERT(!texture->isCPUAccessible());
+
+    ASSERT(textureAngleFormat.depthBits && textureAngleFormat.stencilBits);
+
+    // We have to split the depth & stencil data into 2 buffers.
+    angle::FormatID stagingDepthBufferFormatId;
+    angle::FormatID stagingStencilBufferFormatId;
+
+    switch (textureAngleFormat.id)
+    {
+        case angle::FormatID::D24_UNORM_S8_UINT:
+            stagingDepthBufferFormatId   = angle::FormatID::D24_UNORM_X8_UINT;
+            stagingStencilBufferFormatId = angle::FormatID::S8_UINT;
+            break;
+        case angle::FormatID::D32_FLOAT_S8X24_UINT:
+            stagingDepthBufferFormatId   = angle::FormatID::D32_FLOAT;
+            stagingStencilBufferFormatId = angle::FormatID::S8_UINT;
+            break;
+        default:
+            UNREACHABLE();
+            ANGLE_MTL_TRY(contextMtl, false);
+    }
+
+    const angle::Format &angleStagingDepthFormat = angle::Format::Get(stagingDepthBufferFormatId);
+    const angle::Format &angleStagingStencilFormat =
+        angle::Format::Get(stagingStencilBufferFormatId);
+
+    size_t stagingDepthBufferRowPitch, stagingStencilBufferRowPitch;
+    size_t stagingDepthBuffer2DImageSize, stagingStencilBuffer2DImageSize;
+    mtl::BufferRef stagingDepthbuffer, stagingStencilBuffer;
+
+    ANGLE_TRY(UploadTextureContentsToStagingBuffer(
+        contextMtl, textureAngleFormat, angleStagingDepthFormat, region.size, data, bytesPerRow,
+        &stagingDepthBufferRowPitch, &stagingDepthBuffer2DImageSize, &stagingDepthbuffer));
+
+    ANGLE_TRY(UploadTextureContentsToStagingBuffer(
+        contextMtl, textureAngleFormat, angleStagingStencilFormat, region.size, data, bytesPerRow,
+        &stagingStencilBufferRowPitch, &stagingStencilBuffer2DImageSize, &stagingStencilBuffer));
+
+    mtl::BlitCommandEncoder *encoder = contextMtl->getBlitCommandEncoder();
+
+    encoder->copyBufferToTexture(stagingDepthbuffer, 0, stagingDepthBufferRowPitch,
+                                 stagingDepthBuffer2DImageSize, region.size, texture, slice,
+                                 mipmapLevel, region.origin, MTLBlitOptionDepthFromDepthStencil);
+    encoder->copyBufferToTexture(stagingStencilBuffer, 0, stagingStencilBufferRowPitch,
+                                 stagingStencilBuffer2DImageSize, region.size, texture, slice,
+                                 mipmapLevel, region.origin, MTLBlitOptionStencilFromDepthStencil);
+
+    return angle::Result::Continue;
+}
+
+angle::Result UploadTextureContents(const gl::Context *context,
+                                    const mtl::TextureRef &texture,
+                                    const angle::Format &textureAngleFormat,
+                                    const MTLRegion &region,
+                                    uint32_t mipmapLevel,
+                                    uint32_t slice,
+                                    const uint8_t *data,
+                                    size_t bytesPerRow)
+{
+    ASSERT(texture && texture->valid());
+    ContextMtl *contextMtl = mtl::GetImpl(context);
+
+    if (texture->isCPUAccessible())
+    {
+        // If texture is CPU accessible, just call replaceRegion() directly.
+        texture->replaceRegion(contextMtl, region, mipmapLevel, slice, data, bytesPerRow);
+
+        return angle::Result::Continue;
+    }
+
+    // Texture is not CPU accessible, we need to use staging buffer
+    if (textureAngleFormat.depthBits && textureAngleFormat.stencilBits)
+    {
+        ANGLE_TRY(UploadPackedDepthStencilTextureContentsWithStagingBuffer(
+            contextMtl, texture, textureAngleFormat, region, mipmapLevel, slice, data,
+            bytesPerRow));
+    }
+    else
+    {
+        ANGLE_TRY(UploadTextureContentsWithStagingBuffer(contextMtl, texture, textureAngleFormat,
+                                                         region, mipmapLevel, slice, data,
+                                                         bytesPerRow));
+    }
+
+    return angle::Result::Continue;
+}
+
 }  // namespace
 
 // TextureMtl implementation
@@ -123,8 +327,6 @@ TextureMtl::~TextureMtl() = default;
 
 void TextureMtl::onDestroy(const gl::Context *context)
 {
-    mMetalSamplerState = nil;
-
     releaseTexture(true);
 }
 
@@ -132,7 +334,8 @@ void TextureMtl::releaseTexture(bool releaseImages)
 {
     mFormat = mtl::Format();
 
-    mActualTexture = nullptr;
+    mActualTexture     = nullptr;
+    mMetalSamplerState = nil;
 
     for (RenderTargetMtl &rt : mLayeredRenderTargets)
     {
@@ -229,6 +432,42 @@ angle::Result TextureMtl::ensureTextureCreated(const gl::Context *context)
             mTexImages[layer][mip] = mActualTexture->createSliceMipView(layer, mip);
         }
     }
+
+    // Create sampler state
+    ANGLE_TRY(ensureSamplerStateCreated(context));
+
+    return angle::Result::Continue;
+}
+
+angle::Result TextureMtl::ensureSamplerStateCreated(const gl::Context *context)
+{
+    if (mMetalSamplerState)
+    {
+        return angle::Result::Continue;
+    }
+
+    ContextMtl *contextMtl = mtl::GetImpl(context);
+    DisplayMtl *diplayMtl  = contextMtl->getDisplay();
+
+    mtl::SamplerDesc samplerDesc(mState.getSamplerState());
+
+    if (mFormat.actualAngleFormat().depthBits)
+    {
+#if !TARGET_OS_OSX && !TARGET_OS_MACCATALYST
+        // Only MacOS supports filtering for depth textures, we need to convert to nearest here.
+        samplerDesc.minFilter = MTLSamplerMinMagFilterNearest;
+        samplerDesc.magFilter = MTLSamplerMinMagFilterNearest;
+        if (samplerDesc.mipFilter != MTLSamplerMipFilterNotMipmapped)
+        {
+            samplerDesc.mipFilter = MTLSamplerMipFilterNearest;
+        }
+
+        samplerDesc.maxAnisotropy = 1;
+#endif
+    }
+
+    mMetalSamplerState =
+        diplayMtl->getStateCache().getSamplerState(diplayMtl->getMetalDevice(), samplerDesc);
 
     return angle::Result::Continue;
 }
@@ -509,8 +748,9 @@ angle::Result TextureMtl::generateMipmapCPU(const gl::Context *context)
                                               dstLevelData.get(), dstRowPitch, 0);
 
             // Upload to texture
-            mActualTexture->replaceRegion(contextMtl, MTLRegionMake2D(0, 0, dstWidth, dstHeight),
-                                          mip, layer, dstLevelData.get(), dstRowPitch);
+            ANGLE_TRY(UploadTextureContents(context, mActualTexture, angleFormat,
+                                            MTLRegionMake2D(0, 0, dstWidth, dstHeight), mip, layer,
+                                            dstLevelData.get(), dstRowPitch));
 
             prevLevelWidth    = dstWidth;
             prevLevelHeight   = dstHeight;
@@ -577,27 +817,38 @@ angle::Result TextureMtl::getAttachmentRenderTarget(const gl::Context *context,
 angle::Result TextureMtl::syncState(const gl::Context *context,
                                     const gl::Texture::DirtyBits &dirtyBits)
 {
-    ContextMtl *contextMtl = mtl::GetImpl(context);
-
-    if (dirtyBits.none() && mMetalSamplerState)
+    for (size_t dirtyBit : dirtyBits)
     {
-        return angle::Result::Continue;
-    }
-
-    DisplayMtl *display = contextMtl->getDisplay();
-
-    if (dirtyBits.test(gl::Texture::DIRTY_BIT_SWIZZLE_RED) ||
-        dirtyBits.test(gl::Texture::DIRTY_BIT_SWIZZLE_GREEN) ||
-        dirtyBits.test(gl::Texture::DIRTY_BIT_SWIZZLE_BLUE) ||
-        dirtyBits.test(gl::Texture::DIRTY_BIT_SWIZZLE_ALPHA))
-    {
-        // NOTE(hqle): Metal doesn't support swizzle on many devices. Skip for now.
+        switch (dirtyBit)
+        {
+            case gl::Texture::DIRTY_BIT_MIN_FILTER:
+            case gl::Texture::DIRTY_BIT_MAG_FILTER:
+            case gl::Texture::DIRTY_BIT_WRAP_S:
+            case gl::Texture::DIRTY_BIT_WRAP_T:
+            case gl::Texture::DIRTY_BIT_WRAP_R:
+            case gl::Texture::DIRTY_BIT_MAX_ANISOTROPY:
+            case gl::Texture::DIRTY_BIT_MIN_LOD:
+            case gl::Texture::DIRTY_BIT_MAX_LOD:
+            case gl::Texture::DIRTY_BIT_COMPARE_MODE:
+            case gl::Texture::DIRTY_BIT_COMPARE_FUNC:
+            case gl::Texture::DIRTY_BIT_SRGB_DECODE:
+            case gl::Texture::DIRTY_BIT_BORDER_COLOR:
+                // Recreate sampler state
+                mMetalSamplerState = nil;
+                break;
+            case gl::Texture::DIRTY_BIT_SWIZZLE_RED:
+            case gl::Texture::DIRTY_BIT_SWIZZLE_GREEN:
+            case gl::Texture::DIRTY_BIT_SWIZZLE_BLUE:
+            case gl::Texture::DIRTY_BIT_SWIZZLE_ALPHA:
+                // NOTE(hqle): ES 3.0.
+                break;
+            default:
+                break;
+        }
     }
 
     ANGLE_TRY(ensureTextureCreated(context));
-
-    mMetalSamplerState = display->getStateCache().getSamplerState(
-        display->getMetalDevice(), mtl::SamplerDesc(mState.getSamplerState()));
+    ANGLE_TRY(ensureSamplerStateCreated(context));
 
     return angle::Result::Continue;
 }
@@ -803,7 +1054,8 @@ angle::Result TextureMtl::setSubImageImpl(const gl::Context *context,
     }
 
     // Upload to texture
-    image->replaceRegion(contextMtl, mtlRegion, 0, 0, pixels, sourceRowPitch);
+    ANGLE_TRY(UploadTextureContents(context, image, mFormat.actualAngleFormat(), mtlRegion, 0, 0,
+                                    pixels, sourceRowPitch));
 
     return angle::Result::Continue;
 }
@@ -843,7 +1095,8 @@ angle::Result TextureMtl::convertAndSetSubImage(const gl::Context *context,
                           false, false, false);
 
         // Upload to texture
-        image->replaceRegion(contextMtl, mtlRow, 0, 0, conversionRow.data(), dstRowPitch);
+        ANGLE_TRY(UploadTextureContents(context, image, dstFormat, mtlRow, 0, 0,
+                                        conversionRow.data(), dstRowPitch));
     }
 
     return angle::Result::Continue;
@@ -1010,7 +1263,8 @@ angle::Result TextureMtl::copySubImageCPU(const gl::Context *context,
                                                  conversionRow.data()));
 
         // Upload to texture
-        image->replaceRegion(contextMtl, mtlDstRowArea, 0, 0, conversionRow.data(), dstRowPitch);
+        ANGLE_TRY(UploadTextureContents(context, image, dstFormat, mtlDstRowArea, 0, 0,
+                                        conversionRow.data(), dstRowPitch));
     }
 
     return angle::Result::Continue;

--- a/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_command_buffer.h
+++ b/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_command_buffer.h
@@ -261,6 +261,17 @@ class BlitCommandEncoder final : public CommandEncoder
 
     BlitCommandEncoder &restart();
 
+    BlitCommandEncoder &copyBufferToTexture(const BufferRef &src,
+                                            size_t srcOffset,
+                                            size_t srcBytesPerRow,
+                                            size_t srcBytesPerImage,
+                                            MTLSize srcSize,
+                                            const TextureRef &dst,
+                                            uint32_t dstSlice,
+                                            uint32_t dstLevel,
+                                            MTLOrigin dstOrigin,
+                                            MTLBlitOption blitOption);
+
     BlitCommandEncoder &copyTexture(const TextureRef &dst,
                                     uint32_t dstSlice,
                                     uint32_t dstLevel,

--- a/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_command_buffer.mm
+++ b/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_command_buffer.mm
@@ -788,6 +788,39 @@ BlitCommandEncoder &BlitCommandEncoder::restart()
     }
 }
 
+BlitCommandEncoder &BlitCommandEncoder::copyBufferToTexture(const BufferRef &src,
+                                                            size_t srcOffset,
+                                                            size_t srcBytesPerRow,
+                                                            size_t srcBytesPerImage,
+                                                            MTLSize srcSize,
+                                                            const TextureRef &dst,
+                                                            uint32_t dstSlice,
+                                                            uint32_t dstLevel,
+                                                            MTLOrigin dstOrigin,
+                                                            MTLBlitOption blitOption)
+{
+    if (!src || !dst)
+    {
+        return *this;
+    }
+
+    cmdBuffer().setReadDependency(src);
+    cmdBuffer().setWriteDependency(dst);
+
+    [get() copyFromBuffer:src->get()
+               sourceOffset:srcOffset
+          sourceBytesPerRow:srcBytesPerRow
+        sourceBytesPerImage:srcBytesPerImage
+                 sourceSize:srcSize
+                  toTexture:dst->get()
+           destinationSlice:dstSlice
+           destinationLevel:dstLevel
+          destinationOrigin:dstOrigin
+                    options:blitOption];
+
+    return *this;
+}
+
 BlitCommandEncoder &BlitCommandEncoder::copyTexture(const TextureRef &dst,
                                                     uint32_t dstSlice,
                                                     uint32_t dstLevel,

--- a/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_format_map.json
+++ b/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_format_map.json
@@ -69,7 +69,8 @@
             "A32_FLOAT": "R32G32B32A32_FLOAT",
             "L32_FLOAT": "R32G32B32A32_FLOAT",
             "L32A32_FLOAT": "R32G32B32A32_FLOAT",
-            "D24_UNORM_X8_UINT": "D32_FLOAT"
+            "D24_UNORM_X8_UINT": "D32_FLOAT",
+            "D32_UNORM": "D32_FLOAT"
         },
         "override_ios": {
             "D24_UNORM_S8_UINT": "D32_FLOAT_S8X24_UINT",

--- a/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_format_table_autogen.mm
+++ b/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_format_table_autogen.mm
@@ -262,6 +262,11 @@ void Format::init(const DisplayMtl *display, angle::FormatID intendedFormatId_)
             this->actualFormatId = angle::FormatID::D32_FLOAT;
             break;
 
+        case angle::FormatID::D32_UNORM:
+            this->metalFormat    = MTLPixelFormatDepth32Float;
+            this->actualFormatId = angle::FormatID::D32_FLOAT;
+            break;
+
 #if TARGET_OS_OSX || TARGET_OS_MACCATALYST
         case angle::FormatID::L16A16_FLOAT:
             if (metalDevice.depth24Stencil8PixelFormatSupported)

--- a/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_format_utils.mm
+++ b/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_format_utils.mm
@@ -34,6 +34,14 @@ bool OverrideTextureCaps(const DisplayMtl *display, angle::FormatID formatId, gl
         case angle::FormatID::R8G8B8A8_UNORM_SRGB:
         case angle::FormatID::B8G8R8A8_UNORM:
         case angle::FormatID::B8G8R8A8_UNORM_SRGB:
+        // NOTE: even though iOS devices don't support filtering depth textures, we still report as
+        // supported here in order for the OES_depth_texture extension to be enabled.
+        // During draw call, the filter modes will be converted to nearest.
+        case angle::FormatID::D16_UNORM:
+        case angle::FormatID::D24_UNORM_S8_UINT:
+        case angle::FormatID::D32_FLOAT_S8X24_UINT:
+        case angle::FormatID::D32_FLOAT:
+        case angle::FormatID::D32_UNORM:
             caps->texturable = caps->filterable = caps->textureAttachment = caps->renderbuffer =
                 true;
             return true;
@@ -112,11 +120,12 @@ void GenerateTextureCapsMap(const FormatTable &formatTable,
         tmpTextureExtensions.compressedTexturePVRTCsRGB       = true;
     }
 #endif
-    tmpTextureExtensions.sRGB           = true;
-    tmpTextureExtensions.depth32        = true;
-    tmpTextureExtensions.depth24OES     = true;
-    tmpTextureExtensions.rgb8rgba8      = true;
-    tmpTextureExtensions.textureStorage = true;
+    tmpTextureExtensions.sRGB            = true;
+    tmpTextureExtensions.depth32         = true;
+    tmpTextureExtensions.depth24OES      = true;
+    tmpTextureExtensions.rgb8rgba8       = true;
+    tmpTextureExtensions.textureStorage  = true;
+    tmpTextureExtensions.depthTextureOES = true;
 
     auto formatVerifier = [&](const gl::InternalFormat &internalFormatInfo) {
         angle::FormatID angleFormatId =
@@ -145,14 +154,6 @@ void GenerateTextureCapsMap(const FormatTable &formatTable,
         textureCaps.sampleCounts.clear();
         textureCaps.sampleCounts.insert(0);
         textureCaps.sampleCounts.insert(1);
-
-        if (textureCaps.filterable && mtlFormat.actualFormatId == angle::FormatID::D32_FLOAT)
-        {
-            // Only MacOS support filterable for D32_FLOAT texture
-#if !TARGET_OS_OSX || TARGET_OS_MACCATALYST
-            textureCaps.filterable = false;
-#endif
-        }
 
         textureCapsMap.set(mtlFormat.intendedFormatId, textureCaps);
 

--- a/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_resources.h
+++ b/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_resources.h
@@ -112,6 +112,9 @@ class Texture final : public Resource,
 
     static TextureRef MakeFromMetal(id<MTLTexture> metalTexture);
 
+    // Allow CPU to read & write data directly to this texture?
+    bool isCPUAccessible() const;
+
     void replaceRegion(ContextMtl *context,
                        MTLRegion region,
                        uint32_t mipmapLevel,
@@ -130,6 +133,8 @@ class Texture final : public Resource,
     TextureRef createCubeFaceView(uint32_t face);
     // Create a view of one slice at a level.
     TextureRef createSliceMipView(uint32_t slice, uint32_t level);
+    // Create a view with different format
+    TextureRef createViewWithDifferentFormat(MTLPixelFormat format);
 
     MTLTextureType textureType() const;
     MTLPixelFormat pixelFormat() const;
@@ -163,6 +168,7 @@ class Texture final : public Resource,
             bool supportTextureView);
 
     // Create a texture view
+    Texture(Texture *original, MTLPixelFormat format);
     Texture(Texture *original, MTLTextureType type, NSRange mipmapLevelRange, uint32_t slice);
 
     void syncContent(ContextMtl *context);

--- a/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_state_cache.h
+++ b/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_state_cache.h
@@ -48,6 +48,10 @@ struct StencilDesc
 struct DepthStencilDesc
 {
     DepthStencilDesc();
+    DepthStencilDesc(const DepthStencilDesc &src);
+    DepthStencilDesc(DepthStencilDesc &&src);
+
+    DepthStencilDesc &operator=(const DepthStencilDesc &src);
 
     bool operator==(const DepthStencilDesc &rhs) const;
 
@@ -78,8 +82,12 @@ struct DepthStencilDesc
 struct SamplerDesc
 {
     SamplerDesc();
+    SamplerDesc(const SamplerDesc &src);
+    SamplerDesc(SamplerDesc &&src);
 
     explicit SamplerDesc(const gl::SamplerState &glState);
+
+    SamplerDesc &operator=(const SamplerDesc &src);
 
     // Set default values. All filters are nearest, and addresModes are clamp to edge.
     void reset();
@@ -207,6 +215,10 @@ constexpr PrimitiveTopologyClass kPrimitiveTopologyClassPoint = MTLPrimitiveTopo
 struct RenderPipelineDesc
 {
     RenderPipelineDesc();
+    RenderPipelineDesc(const RenderPipelineDesc &src);
+    RenderPipelineDesc(RenderPipelineDesc &&src);
+
+    RenderPipelineDesc &operator=(const RenderPipelineDesc &src);
 
     bool operator==(const RenderPipelineDesc &rhs) const;
 

--- a/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_state_cache.mm
+++ b/Source/ThirdParty/angle/src/libANGLE/renderer/metal/mtl_state_cache.mm
@@ -245,6 +245,20 @@ DepthStencilDesc::DepthStencilDesc()
 {
     memset(this, 0, sizeof(*this));
 }
+DepthStencilDesc::DepthStencilDesc(const DepthStencilDesc &src)
+{
+    memcpy(this, &src, sizeof(*this));
+}
+DepthStencilDesc::DepthStencilDesc(DepthStencilDesc &&src)
+{
+    memcpy(this, &src, sizeof(*this));
+}
+
+DepthStencilDesc &DepthStencilDesc::operator=(const DepthStencilDesc &src)
+{
+    memcpy(this, &src, sizeof(*this));
+    return *this;
+}
 
 bool DepthStencilDesc::operator==(const DepthStencilDesc &rhs) const
 {
@@ -386,6 +400,14 @@ SamplerDesc::SamplerDesc()
 {
     memset(this, 0, sizeof(*this));
 }
+SamplerDesc::SamplerDesc(const SamplerDesc &src)
+{
+    memcpy(this, &src, sizeof(*this));
+}
+SamplerDesc::SamplerDesc(SamplerDesc &&src)
+{
+    memcpy(this, &src, sizeof(*this));
+}
 
 SamplerDesc::SamplerDesc(const gl::SamplerState &glState) : SamplerDesc()
 {
@@ -398,6 +420,12 @@ SamplerDesc::SamplerDesc(const gl::SamplerState &glState) : SamplerDesc()
     mipFilter = GetMipmapFilter(glState.getMinFilter());
 
     maxAnisotropy = static_cast<uint32_t>(glState.getMaxAnisotropy());
+}
+
+SamplerDesc &SamplerDesc::operator=(const SamplerDesc &src)
+{
+    memcpy(this, &src, sizeof(*this));
+    return *this;
 }
 
 void SamplerDesc::reset()
@@ -568,12 +596,28 @@ RenderPipelineDesc::RenderPipelineDesc()
     rasterizationEnabled = true;
 }
 
+RenderPipelineDesc::RenderPipelineDesc(const RenderPipelineDesc &src)
+{
+    memcpy(this, &src, sizeof(*this));
+}
+
+RenderPipelineDesc::RenderPipelineDesc(RenderPipelineDesc &&src)
+{
+    memcpy(this, &src, sizeof(*this));
+}
+
+RenderPipelineDesc &RenderPipelineDesc::operator=(const RenderPipelineDesc &src)
+{
+    memcpy(this, &src, sizeof(*this));
+    return *this;
+}
+
 bool RenderPipelineDesc::operator==(const RenderPipelineDesc &rhs) const
 {
-    return ANGLE_PROP_EQ(*this, rhs, vertexDescriptor) &&
-           ANGLE_PROP_EQ(*this, rhs, outputDescriptor) &&
-
-           ANGLE_PROP_EQ(*this, rhs, inputPrimitiveTopology);
+    // NOTE(hqle): Use a faster way to compare, i.e take into account
+    // the number of active vertex attributes & render targets.
+    // If that way is used, hash() method must be changed also.
+    return memcmp(this, &rhs, sizeof(*this)) == 0;
 }
 
 size_t RenderPipelineDesc::hash() const

--- a/Source/Urho3D/Graphics/GraphicsDefs.h
+++ b/Source/Urho3D/Graphics/GraphicsDefs.h
@@ -32,7 +32,7 @@ namespace Urho3D
 class Vector3;
 
 /// Graphics capability support level. Web platform (Emscripten) also uses OpenGL ES, but is considered a desktop platform capability-wise
-#if defined(IOS) || defined(TVOS) || defined(__ANDROID__) || defined(__arm__) || defined(__aarch64__)
+#if defined(IOS) || defined(TVOS) || defined(__ANDROID__) || defined(__arm__) || defined(__aarch64__) || defined(URHO3D_ANGLE_VULKAN) || defined(URHO3D_ANGLE_METAL)
 #define MOBILE_GRAPHICS
 #else
 #define DESKTOP_GRAPHICS

--- a/Source/Urho3D/Graphics/GraphicsDefs.h
+++ b/Source/Urho3D/Graphics/GraphicsDefs.h
@@ -32,7 +32,7 @@ namespace Urho3D
 class Vector3;
 
 /// Graphics capability support level. Web platform (Emscripten) also uses OpenGL ES, but is considered a desktop platform capability-wise
-#if defined(IOS) || defined(TVOS) || defined(__ANDROID__) || defined(__arm__) || defined(__aarch64__) || defined(URHO3D_ANGLE_VULKAN) || defined(URHO3D_ANGLE_METAL)
+#if defined(IOS) || defined(TVOS) || defined(__ANDROID__) || defined(__arm__) || defined(__aarch64__)
 #define MOBILE_GRAPHICS
 #else
 #define DESKTOP_GRAPHICS

--- a/Source/Urho3D/Graphics/OpenGL/OGLShaderVariation.cpp
+++ b/Source/Urho3D/Graphics/OpenGL/OGLShaderVariation.cpp
@@ -131,6 +131,11 @@ bool ShaderVariation::Create()
     // Distinguish between VS and PS compile in case the shader code wants to include/omit different things
     shaderCode += type_ == VS ? "#define COMPILEVS\n" : "#define COMPILEPS\n";
 
+    // Add define for GLES on Desktop
+#if defined(GL_ES_VERSION_2_0) && defined(DESKTOP_GRAPHICS)
+    shaderCode += "#define DESKTOP_GRAPHICS\n";
+#endif
+
     // Add define for the maximum number of supported bones
     shaderCode += "#define MAXBONES " + String(Graphics::GetMaxBones()) + "\n";
 

--- a/bin/CoreData/Shaders/GLSL/Lighting.glsl
+++ b/bin/CoreData/Shaders/GLSL/Lighting.glsl
@@ -68,7 +68,7 @@ float GetVertexLightVolumetric(int index, vec3 worldPos)
 
 #ifdef SHADOW
 
-#if defined(DIRLIGHT) && (!defined(GL_ES) || defined(WEBGL))
+#if defined(DIRLIGHT) && (!defined(GL_ES) || defined(WEBGL) || defined(DESKTOP_GRAPHICS))
     #define NUMCASCADES 4
 #else
     #define NUMCASCADES 1
@@ -176,7 +176,7 @@ float GetIntensity(vec3 color)
 
 #ifdef SHADOW
 
-#if defined(DIRLIGHT) && (!defined(GL_ES) || defined(WEBGL))
+#if defined(DIRLIGHT) && (!defined(GL_ES) || defined(WEBGL) || defined(DESKTOP_GRAPHICS))
     #define NUMCASCADES 4
 #else
     #define NUMCASCADES 1
@@ -293,7 +293,7 @@ float GetDirShadowFade(float inLight, float depth)
     return min(inLight + max((depth - cShadowDepthFade.z) * cShadowDepthFade.w, 0.0), 1.0);
 }
 
-#if !defined(GL_ES) || defined(WEBGL)
+#if !defined(GL_ES) || defined(WEBGL) || defined DESKTOP_GRAPHICS
 float GetDirShadow(const vec4 iShadowPos[NUMCASCADES], float depth)
 {
     vec4 shadowPos;

--- a/bin/CoreData/Shaders/GLSL/Uniforms.glsl
+++ b/bin/CoreData/Shaders/GLSL/Uniforms.glsl
@@ -29,7 +29,7 @@ uniform mat4 cViewProj;
 uniform vec4 cUOffset;
 uniform vec4 cVOffset;
 uniform mat4 cZone;
-#if !defined(GL_ES) || defined(WEBGL)
+#if !defined(GL_ES) || defined(WEBGL) || defined(DESKTOP_GRAPHICS)
     uniform mat4 cLightMatrices[4];
 #else
     uniform highp mat4 cLightMatrices[2];


### PR DESCRIPTION
There is another tweak though, need to enable MOBILE_GRAPHICS mode in `Source/Urho3D/Graphics/GraphicsDefs.h` when using ANGLE even if compiling for Mac since Urho3D shadow mapping shader by default only expects one shadow map in GLSL ES mode. This is the default code in `Lighting.glsl`:
```
#if !defined(GL_ES) || defined(WEBGL)
float GetDirShadow(const vec4 iShadowPos[NUMCASCADES], float depth)
{
    vec4 shadowPos;

    if (depth < cShadowSplits.x)
        shadowPos = iShadowPos[0];
    else if (depth < cShadowSplits.y)
        shadowPos = iShadowPos[1];
    else if (depth < cShadowSplits.z)
        shadowPos = iShadowPos[2];
    else
        shadowPos = iShadowPos[3];
        
    return GetDirShadowFade(GetShadow(shadowPos), depth);
}
#else
float GetDirShadow(const highp vec4 iShadowPos[NUMCASCADES], float depth)
{
    return GetDirShadowFade(GetShadow(iShadowPos[0]), depth);
}
#endif
```
If DESKTOP_GRAPHICS is turned on, the app code will create multiple shadow maps (to increase shadow distance), thus the GLSL ES shader wouldn't work correctly. This is mismatch in handling number of shadow maps between app code and GLSL code.
I think we need to inform devs if they want to use ANGLE on Mac in future. They need to support multiple shadow maps in shader if it is GLSL ES running on desktop.